### PR TITLE
Fix permissions for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,15 @@ on:
 permissions:
     contents: write
     pull-requests: write
+    id-token: write
+    issues: write
 
 jobs:
     release-please:
         runs-on: ubuntu-latest
         steps:
           - uses: googleapis/release-please-action@v4
+            id: release
             with:
                 release-type: node
+                token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In order to create a the PR that bumps the version numbers we need to ensure that the workflow has appropriate permissions.