### PR TITLE
ci: use pat to allow checks to run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,4 @@ jobs:
             id: release
             with:
                 release-type: node
-                token: ${{ secrets.GITHUB_TOKEN }}
+                token: ${{ secrets.PAT_FOR_PR }}


### PR DESCRIPTION
As per [release-please documentation](https://github.com/googleapis/release-please-action?tab=readme-ov-file#github-credentials) this ensures that we are using a Personal Access Token to ensure that GitHub checks will also run for PRs created by release-please